### PR TITLE
Fixed build error

### DIFF
--- a/rockspec/luazip-1.2.4-2.rockspec
+++ b/rockspec/luazip-1.2.4-2.rockspec
@@ -68,10 +68,12 @@ build = {
 +  lua_pop(L, nup);  /* remove upvalues */
 +}
 +#endif
++#ifndef LUA_COMPAT_OPENLIB
 +static void luaL_openlib(lua_State *L, const char* name, const luaL_Reg* lib, int nup) {
 +  lua_newtable(L); luaL_setfuncs(L, lib, nup);
 +  if (name) { lua_pushvalue(L, -1); lua_setglobal(L, name); }
 +}
++#endif
 +#endif
 +
  static int pushresult (lua_State *L, int i, const char *filename) {


### PR DESCRIPTION
Fixed build error
```
Installing https://rocks.moonscript.org/luazip-1.2.4-2.src.rock...
Using https://rocks.moonscript.org/luazip-1.2.4-2.src.rock... switching to 'build' mode
Applying patch 1...
successfully patched src/luazip.c
gcc -O2 -fPIC -I/usr/include/lua5.1 -c src/luazip.c -o src/luazip.o -I/usr/include
src/luazip.c:52:13: error: static declaration of ‘luaL_openlib’ follows non-static declaration
 static void luaL_openlib(lua_State *L, const char* name, const luaL_Reg* lib, int nup) {
             ^
In file included from src/luazip.c:15:0:
/usr/include/lua5.1/lauxlib.h:27:22: note: previous declaration of ‘luaL_openlib’ was here
 #define luaI_openlib luaL_openlib
                      ^
/usr/include/lua5.1/lauxlib.h:42:18: note: in expansion of macro ‘luaI_openlib’
 LUALIB_API void (luaI_openlib) (lua_State *L, const char *libname,
                  ^

Error: Build error: Failed compiling object src/luazip.o
```