### PR TITLE
Fix definition of luaL_openlib

### DIFF
--- a/src/luazip.c
+++ b/src/luazip.c
@@ -51,7 +51,8 @@ void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
 #endif
 #ifndef LUA_COMPAT_OPENLIB
 static void luaL_openlib(lua_State *L, const char* name, const luaL_Reg* lib, int nup) {
-  lua_newtable(L); luaL_setfuncs(L, lib, nup);
+  if (name) { lua_newtable(L); lua_insert(L, -(nup + 1)); }
+  luaL_setfuncs(L, lib, nup);
   if (name) { lua_pushvalue(L, -1); lua_setglobal(L, name); }
 }
 #endif

--- a/src/luazip.c
+++ b/src/luazip.c
@@ -21,6 +21,42 @@
 #define ZIPINTERNALFILEHANDLE  "lzipInternalFile"
 #define LUAZIP_MAX_EXTENSIONS 32
 
+#ifndef luaL_reg
+#define luaL_reg luaL_Reg
+#endif
+#ifndef luaL_getn
+#define luaL_getn luaL_len
+#endif
+#ifndef lua_strlen
+#define lua_strlen luaL_len
+#endif
+#ifndef luaL_optlong
+#define luaL_optlong luaL_optinteger
+#endif
+#if LUA_VERSION_NUM >= 501
+#if LUA_VERSION_NUM == 501
+/* From https://github.com/keplerproject/lua-compat-5.2/blob/v0.3/c-api/compat-5.2.c */
+void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
+  luaL_checkstack(L, nup+1, "too many upvalues");
+  for (; l->name != NULL; l++) {  /* fill the table with given functions */
+    int i;
+    lua_pushstring(L, l->name);
+    for (i = 0; i < nup; i++)  /* copy upvalues to the top */
+      lua_pushvalue(L, -(nup + 1));
+    lua_pushcclosure(L, l->func, nup);  /* closure with those upvalues */
+    lua_settable(L, -(nup + 3)); /* table must be below the upvalues, the name and the closure */
+  }
+  lua_pop(L, nup);  /* remove upvalues */
+}
+#endif
+#ifndef LUA_COMPAT_OPENLIB
+static void luaL_openlib(lua_State *L, const char* name, const luaL_Reg* lib, int nup) {
+  lua_newtable(L); luaL_setfuncs(L, lib, nup);
+  if (name) { lua_pushvalue(L, -1); lua_setglobal(L, name); }
+}
+#endif
+#endif
+
 static int pushresult (lua_State *L, int i, const char *filename) {
   if (i) {
     lua_pushboolean(L, 1);

--- a/tests/test_zip.lua
+++ b/tests/test_zip.lua
@@ -34,7 +34,13 @@ function test_open ()
 	assert(f2, err)
 	print("zfile:open OK!")
 	print()
-	
+
+	print("Testing zfile:close")
+	local ok, err = f2:close()
+	assert(ok, err)
+	print("zfile:close OK!")
+	print()
+
 	print("Testing reading by number")
 	local c = f1:read(1)
 	while c ~= nil do


### PR DESCRIPTION
luaL_openlib should only create a new table when the name
argument is not NULL. The table should be inserted below upvalues.

Fixes errors in lzipFile:files() and
lzipInternalFIle:close() under Lua 5.2+ and Lua 5.1
without LUA_COMPAT_OPENLIB.

Added a test for lzipInternalFIle:close().

I also applied the patch from rockspec to source. Patches are typically only used when there is no access to sources.
